### PR TITLE
fix the error

### DIFF
--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ try {
 }
 
 // Start server - SIMPLE VERSION
-app.listen(PORT, () => {
+app.listen(PORT, '0.0.0.0', () => {
   console.log(`🚀 Server running on port ${PORT}`);
   console.log(`❤️  Health: http://localhost:${PORT}/api/health`);
 });


### PR DESCRIPTION
The server was timing out because it was not binding to the correct network interface, making it unreachable from outside its container.

This change modifies the `app.listen()` call in `server.js` to explicitly bind to `'0.0.0.0'`, which resolves the issue by allowing the server to accept connections from any IP address.